### PR TITLE
Better wording in the prompt message

### DIFF
--- a/vk_requests/auth.py
+++ b/vk_requests/auth.py
@@ -279,7 +279,8 @@ class AuthAPI(BaseAuthAPI):
         if self._phone_number:
             code = self._phone_number[len(phone_prefix):-len(phone_suffix)]
         else:
-            prompt = 'Phone number (%s****%s): ' % (phone_prefix, phone_suffix)
+            prompt = 'Enter missing digits of your phone number (%s****%s): '\
+                        % (phone_prefix, phone_suffix)
             code = raw_input(prompt)
 
         params = parse_url_query_params(form_action_url, fragment=False)


### PR DESCRIPTION
VK API requires to enter several digits from a phone number of a user
when it wants to make an addtional check for some security reason.
The user is required to enter only masked digets from his phone number,
but this is not clear from the promt message.

Adjust the text of the message to clearly show what digits
should be entered