### PR TITLE
Add __repr__() method to VkAPIError

### DIFF
--- a/vk_requests/exceptions.py
+++ b/vk_requests/exceptions.py
@@ -70,6 +70,6 @@ class VkAPIError(VkException):
         if self.redirect_uri:
             tokens.append('redirect_uri=\'%s\'' % self.redirect_uri)
         return ','.join(tokens)
-    
+
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self)

--- a/vk_requests/exceptions.py
+++ b/vk_requests/exceptions.py
@@ -70,3 +70,6 @@ class VkAPIError(VkException):
         if self.redirect_uri:
             tokens.append('redirect_uri=\'%s\'' % self.redirect_uri)
         return ','.join(tokens)
+    
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self)


### PR DESCRIPTION
Update VkAPIError so that the repr() call on it returns a useful string with all of the attributes instead of the useless "VkAPIError()"