### PR TITLE
fix deprecation warning: importing the ABCs from collections instead …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests        >= 2.8.1
-six
+six >= 1.13.0
 beautifulsoup4  >= 4.4.1
 websockets;python_version>="3.4"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 PY_VERSION = sys.version_info.major, sys.version_info.minor
 
 install_requires = [
-    'six',
+    'six>=1.13.0',
     'requests>=2.8.1',
     'beautifulsoup4>=4.4.1']
 

--- a/vk_requests/utils.py
+++ b/vk_requests/utils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import bs4
 import requests

--- a/vk_requests/utils.py
+++ b/vk_requests/utils.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
-
 import bs4
 import requests
 import six
@@ -40,7 +35,7 @@ def stringify_values(data):
         items = []
         if isinstance(value, six.string_types):
             items.append(value)
-        elif isinstance(value, Iterable):
+        elif isinstance(value, six.moves.collections_abc.Iterable):
             for v in value:
                 # Convert to str int values
                 if isinstance(v, int):


### PR DESCRIPTION
# Fix based on Issue #41 
Current version of Python 3.8 even produces a warning:
```shell
lib/python3.8/site-packages/vk_requests/utils.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```
For compatibility was used `try-except` construnction.
